### PR TITLE
integrate postgresql repository option for both centos and ubuntu

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,39 @@
+---
+driver:
+  name: lxd_cli
+
+transport:
+  name: sftp
+
+provisioner:
+  name: ansible_playbook
+  roles_path: ../
+  hosts: test-kitchen
+#  ansible_verbose: true
+  ansible_verbose: false
+  ansible_verbosity: 3
+  ansible_extra_flags: <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
+  ansible_yum_repo: http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+  require_chef_omnibus: false
+  require_ansible_omnibus: true
+#  require_chef_for_busser: false
+  enable_yum_epel: true
+  ansible_connection: ssh
+
+platforms:
+  - name: ubuntu-16.04
+  - name: ubuntu-14.04
+  - name: ubuntu-12.04
+  - name: centos-7
+  - name: centos-6
+## FIXME! 'Installing Chef Omnibus to install busser to run tests' not supported = can disable
+##	' sl = self._semlock = _multiprocessing.SemLock(kind, value, maxvalue)\nOSError: [Errno 2] No such file or directory'
+#  - name: alpine-3.4
+
+suites:
+  - name: default
+    run_list:
+    attributes:
+  - name: default-pgdg
+    run_list:
+    attributes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     postgresql_bin_dir: /usr/pgsql-9.5/bin
     postgresql_data_dir: /var/lib/pgsql/9.5/data
-    test_yml: 'test/integration/default-pgdg/default.yml'
+    test_yml: 'role_under_test/test/integration/default-pgdg/default.yml'
   - distro: centos6
     init: /sbin/init
     run_opts: ""

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -vvvv'
 
   # Test role idempotence.
   - idempotence=$(mktemp)

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,8 @@ script:
 
 after_failure:
   # Check what happened on systemd systems.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm cat /etc/passwd'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm cat /etc/group'
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl -l status postgresql.service'
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm journalctl -xe --no-pager'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ services:
   - docker
 
 before_install:
-  - ln -s role_under_test geerlingguy.postgresql
+  - ln -s ansible-role-postgresql ../role_under_test
+  - ln -s ansible-role-postgresql ../geerlingguy.postgresql
   # Pull container
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,37 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     postgresql_bin_dir: /usr/bin
     postgresql_data_dir: /var/lib/pgsql/data
+    test_yml: 'role_under_test/tests/test.yml'
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    postgresql_bin_dir: /usr/pgsql-9.5/bin
+    postgresql_data_dir: /var/lib/pgsql/9.5/data
+    test_yml: 'test/integration/default-pgdg/default.yml'
   - distro: centos6
     init: /sbin/init
     run_opts: ""
     postgresql_bin_dir: /usr/bin
     postgresql_data_dir: /var/lib/pgsql/data
+    test_yml: 'role_under_test/tests/test.yml'
   - distro: ubuntu1604
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     postgresql_bin_dir: /usr/lib/postgresql/9.5/bin
     postgresql_data_dir: /var/lib/postgresql/9.5/main
+    test_yml: 'role_under_test/tests/test.yml'
   - distro: ubuntu1404
     init: /sbin/init
     run_opts: ""
     postgresql_bin_dir: /usr/lib/postgresql/9.3/bin
     postgresql_data_dir: /var/lib/postgresql/9.3/main
+    test_yml: 'role_under_test/tests/test.yml'
   - distro: debian8
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     postgresql_bin_dir: /usr/lib/postgresql/9.4/bin
     postgresql_data_dir: /var/lib/postgresql/9.4/main
+    test_yml: 'role_under_test/tests/test.yml'
 
 services:
   - docker
@@ -41,14 +52,14 @@ script:
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # Ansible syntax check.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/${test_yml} --syntax-check'
 
   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -vvvv'
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/${test_yml} -vvvv'
 
   # Test role idempotence.
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/${test_yml} | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,14 @@ services:
   - docker
 
 before_install:
+  - ln -s role_under_test geerlingguy.postgresql
   # Pull container
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
 
 script:
   - container_id=$(mktemp)
   # Run container in detached state.
-  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD%/*}":/etc/ansible/roles:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/${test_yml} --syntax-check'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,17 @@
 ---
-# RHEL/CentOS only. Set a repository to use for PostgreSQL installation.
+# RHEL/CentOS and Debian/Ubuntu only. Set a repository to use for PostgreSQL installation.
+# https://yum.postgresql.org/repopackages.php
+# https://wiki.postgresql.org/wiki/Apt
 postgresql_enablerepo: ""
+#postgresql_enablerepo: "http://apt.postgresql.org/pub/repos/apt/"
+## only required on debian/ubuntu
+#postgresql_enablerepo_key: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+## RedHat/CentOS
+#postgresql_repo: "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm"
+
+postgresql_pkgnames: [ 'postgresql' ]
+## if different pkg name (different repository)
+#postgresql_pkgnames: [ 'postgresql-9.5' ]
 
 postgresql_user: postgres
 postgresql_group: postgres

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,6 @@ postgresql_enablerepo: ""
 ## RedHat/CentOS
 #postgresql_repo: "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm"
 
-postgresql_pkgnames: [ 'postgresql' ]
 ## if different pkg name (different repository)
 #postgresql_pkgnames: [ 'postgresql-9.5' ]
 

--- a/tasks/initialize.yml
+++ b/tasks/initialize.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Set PostgreSQL environment variables.
   template:
     src: postgres.sh.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # Variable configuration.
 - include: variables.yml
+  when: postgresql_enablerepo is not defined or postgresql_enablerepo == ''
 
 # Setup/install tasks.
 - include: setup-RedHat.yml

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,21 +1,21 @@
 ---
 
 - block:
-    - name: add repository to sources.list
+    - name: Debian | add repository to sources.list
       lineinfile: dest=/etc/apt/sources.list.d/pgdg.list line="deb {{ postgresql_enablerepo }} {{ ansible_distribution_release | lower }}-pgdg main" create=yes
       register: newrepo
-    - name: add repository key
+    - name: Debian | add repository key
       apt_key: url={{ postgresql_enablerepo_key }} state=present
-    - name: Update apt cache
+    - name: Debian | Update apt cache
       apt: update_cache=yes
       when: newrepo.changed
-    - name: Ensure PostgreSQL packages are installed.
-      apt: "name={{ item }} state=installed"
-      with_items: "{{ postgresql_pkgnames | default([]) }}"
-    - name: ensure variables are defined
+#    - name: Debian | Ensure PostgreSQL packages are installed.
+#      apt: "name={{ item }} state=installed"
+#      with_items: "{{ postgresql_pkgnames | default([]) }}"
+    - name: Debian | ensure variables are defined
       set_fact:
         postgresql_daemon: postgresql
-    - name: configure pinning
+    - name: Debian | configure pinning
       blockinfile:
         dest: /etc/apt/preferences.d/pgdg.pref
         block: |
@@ -26,21 +26,20 @@
       when: postgresql_repo_pinning is defined and postgresql_repo_pinning != ''
   when: postgresql_enablerepo is defined and postgresql_enablerepo != ''
 
-- name: Ensure PostgreSQL Python libraries are installed.
+- name: Debian | Ensure PostgreSQL Python libraries are installed.
   apt: "name=python-psycopg2 state=installed"
 
 ## FIXME! travis/trusty: already have pgdg. postgresql calls postgresql-9.6
-- name: Ensure PostgreSQL packages are installed.
+- name: Debian | Ensure PostgreSQL packages are installed.
   apt: "name={{ item }} state=installed"
-  with_items: "{{ postgresql_packages | default([]) }}"
-  when: not (postgresql_enablerepo is defined and postgresql_enablerepo != '')
+  with_items: "{{ postgresql_pkgnames | default( postgresql_packages ) }}"
 
-- name: Ensure all configured locales are present.
+- name: Debian | Ensure all configured locales are present.
   locale_gen: "name={{ item }} state=present"
   with_items: "{{ postgresql_locales }}"
   register: locale_gen_result
 
-- name: Force-restart PostgreSQL after new locales are generated.
+- name: Debian | Force-restart PostgreSQL after new locales are generated.
   service:
     name: "{{ postgresql_daemon }}"
     state: restarted

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,10 +3,12 @@
 - block:
     - name: add repository to sources.list
       lineinfile: dest=/etc/apt/sources.list.d/pgdg.list line="deb {{ postgresql_enablerepo }} {{ ansible_distribution_release | lower }}-pgdg main" create=yes
+      register: newrepo
     - name: add repository key
       apt_key: url={{ postgresql_enablerepo_key }} state=present
     - name: Update apt cache
       apt: update_cache=yes
+      when: newrepo.changed
     - name: Ensure PostgreSQL packages are installed.
       apt: "name={{ item }} state=installed"
       with_items: "{{ postgresql_pkgnames | default([]) }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,10 +1,27 @@
 ---
+
+- block:
+    - name: add repository to sources.list
+      lineinfile: dest=/etc/apt/sources.list.d/pgdg.list line="deb {{ postgresql_enablerepo }} {{ ansible_distribution_release | lower }}-pgdg main" create=yes
+    - name: add repository key
+      apt_key: url={{ postgresql_enablerepo_key }} state=present
+    - name: Update apt cache
+      apt: update_cache=yes
+    - name: Ensure PostgreSQL packages are installed.
+      apt: "name={{ item }} state=installed"
+      with_items: "{{ postgresql_pkgnames }}"
+    - name: ensure variables are defined
+      set_fact:
+        postgresql_daemon: postgresql
+  when: postgresql_enablerepo is defined and postgresql_enablerepo != ''
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt: "name=python-psycopg2 state=installed"
 
 - name: Ensure PostgreSQL packages are installed.
   apt: "name={{ item }} state=installed"
   with_items: "{{ postgresql_packages }}"
+  when: not (postgresql_enablerepo is defined and postgresql_enablerepo != '')
 
 - name: Ensure all configured locales are present.
   locale_gen: "name={{ item }} state=present"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,18 +9,28 @@
       apt: update_cache=yes
     - name: Ensure PostgreSQL packages are installed.
       apt: "name={{ item }} state=installed"
-      with_items: "{{ postgresql_pkgnames }}"
+      with_items: "{{ postgresql_pkgnames | default([]) }}"
     - name: ensure variables are defined
       set_fact:
         postgresql_daemon: postgresql
+    - name: configure pinning
+      blockinfile:
+        dest: /etc/apt/preferences.d/pgdg.pref
+        block: |
+          Package: *
+          Pin: release o=apt.postgresql.org
+          Pin-Priority: {{ postgresql_repo_pinning }}
+        marker: "# {mark} ANSIBLE MANAGED BLOCK: repo pinning"
+      when: postgresql_repo_pinning is defined and postgresql_repo_pinning != ''
   when: postgresql_enablerepo is defined and postgresql_enablerepo != ''
 
 - name: Ensure PostgreSQL Python libraries are installed.
   apt: "name=python-psycopg2 state=installed"
 
+## FIXME! travis/trusty: already have pgdg. postgresql calls postgresql-9.6
 - name: Ensure PostgreSQL packages are installed.
   apt: "name={{ item }} state=installed"
-  with_items: "{{ postgresql_packages }}"
+  with_items: "{{ postgresql_packages | default([]) }}"
   when: not (postgresql_enablerepo is defined and postgresql_enablerepo != '')
 
 - name: Ensure all configured locales are present.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,7 +27,7 @@
   when: postgresql_enablerepo is defined and postgresql_enablerepo != ''
 
 - name: Debian | Ensure PostgreSQL Python libraries are installed.
-  apt: "name=python-psycopg2 state=installed"
+  apt: "name=python-psycopg2 state=installed update_cache=yes"
 
 ## FIXME! travis/trusty: already have pgdg. postgresql calls postgresql-9.6
 - name: Debian | Ensure PostgreSQL packages are installed.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: Install new repository
+- name: RedHat | Install new repository
   yum: name="{{ postgresql_repo }}" state=present
   when: postgresql_repo is defined and postgresql_repo != ''
 
-- name: Ensure PostgreSQL packages are installed.
+- name: RedHat | Ensure PostgreSQL packages are installed.
 #  package: "name={{ item }} state=installed enablerepo={{ postgresql_enablerepo }} update_cache=yes"
   package: "name={{ item }} state=installed update_cache=yes"
   with_items: "{{ postgresql_pkgnames | default( postgresql_packages ) }}"
 
-- name: Ensure PostgreSQL Python libraries are installed.
+- name: RedHat | Ensure PostgreSQL Python libraries are installed.
   package: "name=python-psycopg2 state=installed enablerepo={{ postgresql_enablerepo }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: Install new reposity
+- name: Install new repository
   yum: name="{{ postgresql_repo }}" state=present
   when: postgresql_repo is defined and postgresql_repo != ''
 
 - name: Ensure PostgreSQL packages are installed.
 #  package: "name={{ item }} state=installed enablerepo={{ postgresql_enablerepo }} update_cache=yes"
   package: "name={{ item }} state=installed update_cache=yes"
-  with_items: "{{ postgresql_packages | default([]) }}"
+  with_items: "{{ postgresql_pkgnames | default( postgresql_packages ) }}"
 
 - name: Ensure PostgreSQL Python libraries are installed.
   package: "name=python-psycopg2 state=installed enablerepo={{ postgresql_enablerepo }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,7 +7,7 @@
 - name: Ensure PostgreSQL packages are installed.
 #  package: "name={{ item }} state=installed enablerepo={{ postgresql_enablerepo }} update_cache=yes"
   package: "name={{ item }} state=installed update_cache=yes"
-  with_items: "{{ postgresql_packages }}"
+  with_items: "{{ postgresql_packages | default([]) }}"
 
 - name: Ensure PostgreSQL Python libraries are installed.
   package: "name=python-psycopg2 state=installed enablerepo={{ postgresql_enablerepo }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,12 @@
 ---
+
+- name: Install new reposity
+  yum: name="{{ postgresql_repo }}" state=present
+  when: postgresql_repo is defined and postgresql_repo != ''
+
 - name: Ensure PostgreSQL packages are installed.
-  package: "name={{ item }} state=installed enablerepo={{ postgresql_enablerepo }}"
+#  package: "name={{ item }} state=installed enablerepo={{ postgresql_enablerepo }} update_cache=yes"
+  package: "name={{ item }} state=installed update_cache=yes"
   with_items: "{{ postgresql_packages }}"
 
 - name: Ensure PostgreSQL Python libraries are installed.

--- a/test/integration/default-pgdg/bats/idempotency.bats
+++ b/test/integration/default-pgdg/bats/idempotency.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+#
+
+#
+# Idempotence test
+# from https://github.com/neillturner/kitchen-ansible/issues/92
+#
+
+@test "Second run should change nothing" {
+#    skip
+    run bash -c "ansible-playbook -i /tmp/kitchen/hosts /tmp/kitchen/default.yml -c local 2>&1 | tee /tmp/idempotency.test | grep -q 'changed=0.*failed=0' && exit 0 || exit 1"
+    [ "$status" -eq 0 ]
+}
+

--- a/test/integration/default-pgdg/default.yml
+++ b/test/integration/default-pgdg/default.yml
@@ -1,0 +1,43 @@
+---
+
+- hosts: all
+#  vars:
+#    - a:
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes
+      when: ansible_os_family == 'Debian'
+
+    - name: Set postgresql upstream repo for Ubuntu
+      set_fact:
+        postgresql_enablerepo: "http://apt.postgresql.org/pub/repos/apt/"
+        postgresql_enablerepo_key: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+#        postgresql_enablerepo_version: '9.5'
+        postgresql_pkgnames:
+#          - postgresql         ## postgresql matchs latest release
+          - postgresql-9.5
+        __postgresql_version: "9.5"
+      when: ansible_distribution == 'Ubuntu'
+    - set_fact:
+        postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+        postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+        postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+        postgresql_daemon: postgresql
+      when: ansible_distribution == 'Ubuntu'
+
+    - set_fact:
+        postgresql_repo: "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm"
+#        postgresql_enablerepo: "pgdg-95"
+        postgresql_packages:
+          - postgresql95
+      when: ansible_os_family == 'RedHat' and ansible_distribution_version.split('.')[0] == '7'
+    - set_fact:
+        postgresql_repo: "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-6-x86_64/pgdg-redhat95-9.5-3.noarch.rpm"
+#        postgresql_enablerepo: "pgdg-95"
+        postgresql_packages:
+          - postgresql95
+      when: ansible_os_family == 'RedHat' and ansible_distribution_version.split('.')[0] == '6'
+
+  roles:
+    - geerlingguy.postgresql
+

--- a/test/integration/default-pgdg/serverspec/Gemfile
+++ b/test/integration/default-pgdg/serverspec/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'serverspec'
+gem 'rake'
+## for junit output and jenkins support
+## FIXME! travis: 'Could not find gem 'yarjuf' in any of the gem sources listed in your Gemfile or available on this machine.'
+#gem 'yarjuf'
+

--- a/test/integration/default-pgdg/serverspec/Rakefile
+++ b/test/integration/default-pgdg/serverspec/Rakefile
@@ -1,0 +1,9 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = '*_spec.rb'
+end
+
+task :default => :spec
+

--- a/test/integration/default-pgdg/serverspec/postgres_spec.rb
+++ b/test/integration/default-pgdg/serverspec/postgres_spec.rb
@@ -1,0 +1,48 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe package('postgresql-9.5'), :if => os[:family] == 'ubuntu' do
+  it { should be_installed }
+end
+describe package('postgresql95'), :if => os[:family] == 'redhat' do
+  it { should be_installed }
+end
+
+describe service('postgresql') do
+  it { should be_enabled   }
+  it { should be_running   }
+end  
+
+describe process("postgres") do
+  its(:user) { should eq "postgres" }
+## not on centos
+#  its(:args) { should match /main\/postgresql.conf/ }
+end
+
+describe port(5432) do
+  it { should be_listening }
+end
+
+describe file('/var/lib/postgresql/9.5/main'), :if => os[:family] == 'ubuntu' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.5/main'), :if => os[:family] == 'ubuntu' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.5/main/pg_hba.conf'), :if => os[:family] == 'ubuntu' do
+  it { should be_file }
+end
+describe file('/usr/lib/postgresql/9.5/bin'), :if => os[:family] == 'ubuntu' do
+  it { should be_directory }
+end
+
+
+describe file('/var/lib/pgsql'), :if => os[:family] == 'redhat' do
+  it { should be_directory }
+end
+describe file('/var/lib/pgsql/data/pg_hba.conf'), :if => os[:family] == 'redhat' do
+  it { should be_file }
+end
+

--- a/test/integration/default-pgdg/serverspec/run-local-tests.sh
+++ b/test/integration/default-pgdg/serverspec/run-local-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -x
+## get consistent ruby2+bundler env on each distribution
+
+location=`dirname "$0"`
+cd $location
+v=2.3
+
+## docker environment in travis missing few utils
+[ -f /etc/debian_version ] && apt-get install -y curl
+[ -f /etc/redhat-release ] && yum -y install which
+
+curl -sSL https://get.rvm.io | bash
+#[ -f $HOME/.rvm/scripts/rvm ] && . $HOME/.rvm/scripts/rvm
+#[ -d /usr/local/rvm ] && . /etc/profile.d/rvm.sh
+
+## troubleshoot
+type rvm | head -1
+env
+
+#export PATH=/usr/local/rvm/bin:$PATH
+
+bash -l -c "rvm install $v"
+bash -l -c "rvm use $v"
+bash -l -c "rvm use $v --default"
+bash -l -c "gem install bundler"
+bash -l -c "bundle install --path ./gems"
+if [ "X$USER" != "Xroot" -a "X$USER" != "X" ]; then
+    bash -l -c "env rvmsudo_secure_path=1 rvmsudo bundle exec rake spec"
+else
+    bash -l -c "bundle exec rake spec"
+fi
+

--- a/test/integration/default/bats/idempotency.bats
+++ b/test/integration/default/bats/idempotency.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+#
+
+#
+# Idempotence test
+# from https://github.com/neillturner/kitchen-ansible/issues/92
+#
+
+@test "Second run should change nothing" {
+#    skip
+    run bash -c "ansible-playbook -i /tmp/kitchen/hosts /tmp/kitchen/default.yml -c local 2>&1 | tee /tmp/idempotency.test | grep -q 'changed=0.*failed=0' && exit 0 || exit 1"
+    [ "$status" -eq 0 ]
+}
+

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,8 @@
+---
+
+- hosts: all
+#  vars:
+#    - a:
+  roles:
+    - geerlingguy.postgresql
+

--- a/test/integration/default/serverspec/Gemfile
+++ b/test/integration/default/serverspec/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'serverspec'
+gem 'rake'
+## for junit output and jenkins support
+## FIXME! travis: 'Could not find gem 'yarjuf' in any of the gem sources listed in your Gemfile or available on this machine.'
+#gem 'yarjuf'
+

--- a/test/integration/default/serverspec/Rakefile
+++ b/test/integration/default/serverspec/Rakefile
@@ -1,0 +1,9 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = '*_spec.rb'
+end
+
+task :default => :spec
+

--- a/test/integration/default/serverspec/postgres_spec.rb
+++ b/test/integration/default/serverspec/postgres_spec.rb
@@ -1,0 +1,53 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe service('postgresql') do
+  it { should be_enabled   }
+  it { should be_running   }
+end  
+
+describe process("postgres") do
+  its(:user) { should eq "postgres" }
+## not on centos
+#  its(:args) { should match /main\/postgresql.conf/ }
+end
+
+describe port(5432) do
+  it { should be_listening }
+end
+
+describe file('/var/lib/postgresql/9.5/main'), :if => os[:family] == 'ubuntu' && os[:release] == '16.04' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.5/main'), :if => os[:family] == 'ubuntu' && os[:release] == '16.04' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.5/main/pg_hba.conf'), :if => os[:family] == 'ubuntu' && os[:release] == '16.04' do
+  it { should be_file }
+end
+describe file('/usr/lib/postgresql/9.5/bin'), :if => os[:family] == 'ubuntu' && os[:release] == '16.04' do
+  it { should be_directory }
+end
+
+describe file('/var/lib/postgresql/9.3/main'), :if => os[:family] == 'ubuntu' && os[:release] == '14.04' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.3/main'), :if => os[:family] == 'ubuntu' && os[:release] == '14.04' do
+  it { should be_directory }
+end
+describe file('/etc/postgresql/9.3/main/pg_hba.conf'), :if => os[:family] == 'ubuntu' && os[:release] == '14.04' do
+  it { should be_file }
+end
+describe file('/usr/lib/postgresql/9.3/bin'), :if => os[:family] == 'ubuntu' && os[:release] == '14.04' do
+  it { should be_directory }
+end
+
+describe file('/var/lib/pgsql'), :if => os[:family] == 'redhat' do
+  it { should be_directory }
+end
+describe file('/var/lib/pgsql/data/pg_hba.conf'), :if => os[:family] == 'redhat' do
+  it { should be_file }
+end
+

--- a/test/integration/default/serverspec/run-local-tests.sh
+++ b/test/integration/default/serverspec/run-local-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -x
+## get consistent ruby2+bundler env on each distribution
+
+location=`dirname "$0"`
+cd $location
+v=2.3
+
+## docker environment in travis missing few utils
+[ -f /etc/debian_version ] && apt-get install -y curl
+[ -f /etc/redhat-release ] && yum -y install which
+
+curl -sSL https://get.rvm.io | bash
+#[ -f $HOME/.rvm/scripts/rvm ] && . $HOME/.rvm/scripts/rvm
+#[ -d /usr/local/rvm ] && . /etc/profile.d/rvm.sh
+
+## troubleshoot
+type rvm | head -1
+env
+
+#export PATH=/usr/local/rvm/bin:$PATH
+
+bash -l -c "rvm install $v"
+bash -l -c "rvm use $v"
+bash -l -c "rvm use $v --default"
+bash -l -c "gem install bundler"
+bash -l -c "bundle install --path ./gems"
+if [ "X$USER" != "Xroot" -a "X$USER" != "X" ]; then
+    bash -l -c "env rvmsudo_secure_path=1 rvmsudo bundle exec rake spec"
+else
+    bash -l -c "bundle exec rake spec"
+fi
+

--- a/test/vagrant/Vagrantfile
+++ b/test/vagrant/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+## for xenial, need to manually install python as python v2 is not in default image.
+    #config.vm.box = "ubuntu/xenial64"
+    #config.vm.box = "boxcutter/ubuntu1604"
+    config.vm.box = "ubuntu/trusty64"
+    #config.vm.box = "centos/7"
+
+    config.vm.provision :ansible do |ansible|
+       ansible.playbook = "site.yml"
+       #ansible.verbose = "vvvv"
+       #ansible.host_key_checking = false
+       #ansible.limit = 'all'
+       ansible.sudo = true
+       ansible.extra_vars = { ansible_ssh_user: 'vagrant' }
+       ansible.groups = {
+          "myrole" => ["vhost" ],
+       }
+    end
+
+    config.vm.define "vhost" do |vhost|
+        vhost.vm.hostname = "vhost"
+        vhost.vm.provider "virtualbox" do |v|
+          v.memory = 1024
+        end
+    end
+
+end
+

--- a/test/vagrant/ansible.cfg
+++ b/test/vagrant/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults] 
+roles_path = ../../../
+

--- a/test/vagrant/site.yml
+++ b/test/vagrant/site.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: all
+  roles:
+    - juju4.myrole
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,9 +8,9 @@
       - name: jdoe
 
   pre_tasks:
-    - name: Update apt cache.
-      apt: update_cache=yes
-      when: ansible_os_family == 'Debian'
+#    - name: Update apt cache.
+#      apt: update_cache=yes
+#      when: ansible_os_family == 'Debian'
 
     - name: Set custom variable name for old CentOS 6 PostgreSQL install.
       set_fact:

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -5,6 +5,5 @@ __postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
 __postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
   - postgresql-contrib
   - libpq-dev

--- a/vars/Ubuntu-14.yml
+++ b/vars/Ubuntu-14.yml
@@ -5,6 +5,5 @@ __postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
 __postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
   - postgresql-contrib
   - libpq-dev

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -5,6 +5,5 @@ __postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
 __postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
   - postgresql-contrib
   - libpq-dev


### PR DESCRIPTION
Hello @geerlingguy 

This allow direct use of postgres official repository as documented here
https://yum.postgresql.org/repopackages.php
https://wiki.postgresql.org/wiki/Apt

This way, we can have postgresql 9.5 on any platform.

I also have kitchen/lxd_cli config with serverspec test that I didn't push for now. depends on you. can add kitchen/vagrant too.
I validated role on trusty, xenial and centos7 both in default config and with postgres repo.
