### PR TITLE
Debian 8 don’t ship sudo package

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: Ensure Sudo package is installed.
+  apt: "name=sudo state=installed"
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt: "name=python-psycopg2 state=installed"
 


### PR DESCRIPTION
Hi,
The role needed to do some check with become flag

```
TASK [geerlingguy.postgresql : Ensure PostgreSQL databases are present.] *******
failed: [pouet] (item={u'name': u'mastodon'}) => {"failed": true, "item": {"name": "mastodon"}, "module_stderr": "/bin/sh: 1: sudo: not found\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```