### PR TITLE
Configuration for Amazon Linux AMI 2017.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If overriding, make sure you copy all of the existing entries from `defaults/mai
         login_user: # defaults to 'postgresql_user'
         login_unix_socket: # defaults to 1st of postgresql_unix_socket_directories
         port: # defaults to not set
+        owner: # defaults to 'postgresql_user'
         state: # defaults to 'present'
 
 A list of databases to ensure exist on the server. Only the `name` is required; all other properties are optional.

--- a/vars/RedHat-2017.yml
+++ b/vars/RedHat-2017.yml
@@ -1,0 +1,12 @@
+---
+__postgresql_version: "9.2"
+# PGDATA directory is set in /etc/sysconfig/pgsql/postgresql
+__postgresql_data_dir: "/var/lib/pgsql9/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql9/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs


### PR DESCRIPTION
This is the PostgreSQL `vars/*` config file for Amazon Linux AMI 2017.03

Amazon Linux AMI is mostly like RHEL 6 (although it's diverging over time). They number their releases as year.month, so the major version becomes "2017".