### PR TITLE
Add item to user for encrypted password.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,12 +38,14 @@ postgresql_databases: []
   #   login_user: # defaults to '{{ postgresql_user }}'
   #   login_unix_socket: # defaults to 1st of postgresql_unix_socket_directories
   #   port: # defaults to not set
+  #   owner: # defaults to postgresql_user
   #   state: # defaults to 'present'
 
 # Users to ensure exist.
 postgresql_users: []
   # - name: jdoe #required; the rest are optional
   #   password: # defaults to not set
+  #   encrypted: # defaults to not set
   #   priv: # defaults to not set
   #   role_attr_flags: # defaults to not set
   #   db: # defaults to not set

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -3,6 +3,7 @@
   postgresql_user:
     name: "{{ item.name }}"
     password: "{{ item.password | default(omit) }}"
+    encrypted: "{{ item.encrypted | default(omit) }}"
     priv: "{{ item.priv | default(omit) }}"
     role_attr_flags: "{{ item.role_attr_flags | default(omit) }}"
     db: "{{ item.db | default(omit) }}"


### PR DESCRIPTION
@geerlingguy `encrypted` defaults to `no` apparently, and when I try to run the role on PostgreSQL 10.1 I get `psycopg2.NotSupportedError: UNENCRYPTED PASSWORD is no longer supported`. I'm trying to set `encrypted: yes` but I noticed the role doesn't take this item into account.

See https://github.com/ansible/ansible/issues/25823#issuecomment-336433464 that had the solution.