### PR TITLE
Changed behaviour when pg_hba is modified, so restart is not necessary

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: restart postgresql
   service: "name={{ postgresql_daemon }} state=restarted sleep=5"
+
+- name: refresh pg_hba
+  become: yes
+  become_user: postgres
+  command: psql -c "SELECT pg_reload_conf();"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,7 @@
     owner: "{{ postgresql_user }}"
     group: "{{ postgresql_group }}"
     mode: 0600
-  notify: restart postgresql
+  notify: refresh pg_hba
   when: postgresql_hba_entries
 
 - name: Ensure PostgreSQL unix socket dirs exist.


### PR DESCRIPTION
I manage some postgres servers which should not be restarted, but pg_hba is sometimes modified, and we need to wait for the right moment, or do it manually.. Long story short, we ended up in a quite messy spot, so I created this customization which hits our pain point.. Hope you find it useful and merge it.. 