### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   - distro: centos6
     postgresql_bin_dir: /usr/bin
     postgresql_data_dir: /var/lib/pgsql/data
+  - distro: ubuntu1804
+    postgresql_bin_dir: /usr/lib/postgresql/10/bin
+    postgresql_data_dir: /var/lib/postgresql/10/main
   - distro: ubuntu1604
     postgresql_bin_dir: /usr/lib/postgresql/9.5/bin
     postgresql_data_dir: /var/lib/postgresql/9.5/main

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,0 +1,10 @@
+---
+__postgresql_version: "10"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev


### PR DESCRIPTION
Ubuntu 18.04 ships with PostgreSQL 10. 

This MR adds support for Ubuntu 18.04 and fixes a small yet fatal issue when creating users with PG10.