### PR TITLE
Configure: make sure to correctly capture autovacuum option line

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Configure global settings.
   lineinfile:
     dest: "{{ postgresql_config_path }}/postgresql.conf"
-    regexp: "^#?{{ item.option }}.+$"
+    regexp: "^#?{{ item.option }}\\W+.+$"
     line: "{{ item.option }} = '{{ item.value }}'"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ postgresql_global_config_options }}"


### PR DESCRIPTION
I noticed that the configure task created one `autovacuum` line every time it ran, because the `lineinfile.regexp` did catch `autovacuum_foo` which seemed to be earlier in the config file.

By matching on a non-word character, we make sure that we correctly capture the whole word and not just the start.