### PR TITLE
Create users before databases

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,5 +19,5 @@
     enabled: yes
 
 # Configure PostgreSQL.
-- import_tasks: databases.yml
 - import_tasks: users.yml
+- import_tasks: databases.yml


### PR DESCRIPTION
When I trying create user and database that he own like this:
  postgresql_users:                                                                                                                                     
    - name: project                                                                                                                                     
      password: projectpassword                                                                                                                         
  postgresql_databases:                                                                                                                                 
    - name: project
      owner: project

I got error:
    role "project" does not exist

This changes fixes it