### PR TITLE
Add support for populating a new db

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If overriding, make sure you copy all of the existing entries from `defaults/mai
         port: # defaults to not set
         owner: # defaults to postgresql_user
         state: # defaults to 'present'
+        run_sql_script: # the location to an SQL script in templates/postgresql_population_scripts/ to run on this database when first created
 
 A list of databases to ensure exist on the server. Only the `name` is required; all other properties are optional.
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,6 +6,8 @@
   vars:
     postgresql_databases:
       - name: example
+      - name: populated_example
+        run_sql_script: populate_example.sql.j2
     postgresql_users:
       - name: jdoe
 

--- a/molecule/default/templates/postgresql_population_scripts/populate_example.sql.j2
+++ b/molecule/default/templates/postgresql_population_scripts/populate_example.sql.j2
@@ -1,0 +1,8 @@
+CREATE TABLE users (
+  name VARCHAR(50) NOT NULL,
+  PRIMARY KEY (name));
+
+INSERT INTO users (name)
+VALUES ('alice');
+INSERT INTO users (name)
+VALUES ('bob');

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,3 +26,6 @@
     group: "{{ postgresql_group }}"
     mode: 02775
   with_items: "{{ postgresql_unix_socket_directories }}"
+
+- name: Ensure authentication policy is applied
+  meta: flush_handlers

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -19,3 +19,34 @@
   # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
   vars:
     ansible_ssh_pipelining: true
+  register: postgresql_databases_results
+
+- name: Copy population scripts to host
+  template:
+    src: "postgresql_population_scripts/{{ item.item.run_sql_script }}"
+    dest: "/tmp/{{ item.item.run_sql_script }}"
+  with_items: "{{ postgresql_databases_results.results }}"
+  when: item.changed and 'run_sql_script' in item.item and ('state' not in item.item or item.item.state != 'absent')
+
+- name: Ensure PostgreSQL databases are populated.
+  postgresql_db:
+    name: "{{ item.item.name }}"
+    lc_collate: "{{ item.item.lc_collate | default('en_US.UTF-8') }}"
+    lc_ctype: "{{ item.item.lc_ctype | default('en_US.UTF-8') }}"
+    encoding: "{{ item.item.encoding | default('UTF-8') }}"
+    template: "{{ item.item.template | default('template0') }}"
+    login_host: "{{ item.item.login_host | default('localhost') }}"
+    login_password: "{{ item.item.login_password | default(omit) }}"
+    login_user: "{{ item.item.login_user | default(postgresql_user) }}"
+    login_unix_socket: "{{ item.item.login_unix_socket | default(postgresql_unix_socket_directories[0]) }}"
+    port: "{{ item.item.port | default(omit) }}"
+    owner: "{{ item.item.owner | default(postgresql_user) }}"
+    state: "restore"
+    target: "/tmp/{{ item.item.run_sql_script }}"
+  with_items: "{{ postgresql_databases_results.results }}"
+  when: item.changed and 'run_sql_script' in item.item and ('state' not in item.item or item.item.state != 'absent')
+  become: true
+  become_user: "{{ postgresql_user }}"
+  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
+  vars:
+    ansible_ssh_pipelining: true


### PR DESCRIPTION
This adds support to run a certain SQL script when the database is initially created. This is useful for applications that use PostgreSQL but will not populate the databases they need themselves (more common than you'd think!) and lowers the work required in writing a playbook for such applications.