### PR TITLE
Feature/debian based pgsql version select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
 script:
   # Run tests.
   - molecule test
+  - molecule test -s custompgsqlversion
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # RHEL/CentOS only. Set a repository to use for PostgreSQL installation.
 postgresql_enablerepo: ""
 
+# Debian/Ubuntu only. Enable a repository to use for PostgreSQL installation.
+postgresql_apt_enablerepo: false
+
 # Set postgresql state when configuration changes are made. Recommended values:
 # `restarted` or `reloaded`
 postgresql_restarted_state: "restarted"

--- a/molecule/custompgsqlversion/molecule.yml
+++ b/molecule/custompgsqlversion/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yaml-lint.yml
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  options:
+    v: true
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
+scenario:
+  name: custompgsqlversion
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/custompgsqlversion/playbook.yml
+++ b/molecule/custompgsqlversion/playbook.yml
@@ -1,0 +1,37 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    postgresql_databases:
+      - name: example
+    postgresql_users:
+      - name: jdoe
+    postgresql_custom_version: '10'
+    postgresql_enablerepo: 'YES'
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=true cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+    - name: Set custom variables for old CentOS 6 PostgreSQL install.
+      set_fact:
+        postgresql_hba_entries: []
+        postgresql_global_config_options:
+          - option: unix_socket_directory
+            value: '{{ postgresql_unix_socket_directories[0] }}'
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_version.split('.')[0] == '6'
+
+  roles:
+    - role: geerlingguy.postgresql
+
+  post_tasks:
+    - name: Verify postgres is running.
+      command: "{{ postgresql_bin_path }}/pg_ctl -D {{ postgresql_data_dir }} status"
+      changed_when: false
+      become: true
+      become_user: postgres

--- a/molecule/custompgsqlversion/playbook.yml
+++ b/molecule/custompgsqlversion/playbook.yml
@@ -9,7 +9,7 @@
     postgresql_users:
       - name: jdoe
     postgresql_custom_version: '10'
-    postgresql_enablerepo: 'YES'
+    postgresql_apt_enablerepo: true
 
   pre_tasks:
     - name: Update apt cache.

--- a/molecule/custompgsqlversion/tests/test_default.py
+++ b/molecule/custompgsqlversion/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,15 +3,13 @@
   apt_key:
     url: "{{ postgresql_repo_key }}"
     state: present
-  when:
-    - postgresql_enablerepo == 'YES'
+  when: postgresql_apt_enablerepo
 
 - name: Enable external APT repository reference
   apt_repository:
     repo: "{{ postgresql_repo_reference }}"
     state: present
-  when:
-    - postgresql_enablerepo == 'YES'
+  when: postgresql_apt_enablerepo
 
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,18 @@
 ---
+- name: Enable external APT repository key
+  apt_key:
+    url: "{{ postgresql_repo_key }}"
+    state: present
+  when:
+    - postgresql_enablerepo == 'YES'
+
+- name: Enable external APT repository reference
+  apt_repository:
+    repo: "{{ postgresql_repo_reference }}"
+    state: present
+  when:
+    - postgresql_enablerepo == 'YES'
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:
     name: "{{ postgresql_python_library }}"

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -19,7 +19,7 @@
     postgresql_repo_reference: "{{ __postgresql_repo_reference }}"
   when:
     - ansible_os_family == 'Debian'
-    - postgresql_enablerepo == 'YES'
+    - postgresql_apt_enablerepo == true
     - postgresql_repo_reference is not defined
 
 - name: Define postgresql_repo_key.
@@ -27,7 +27,7 @@
     postgresql_repo_key: "{{ __postgresql_repo_key }}"
   when:
     - ansible_os_family == 'Debian'
-    - postgresql_enablerepo == 'YES'
+    - postgresql_apt_enablerepo == true
     - postgresql_repo_key is not defined
 
 - name: Define postgresql_packages.

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -8,6 +8,28 @@
   include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
   when: ansible_os_family == 'RedHat'
 
+- name: Include Custom Version OS-specific variables (Debian)
+  include_vars: custom-version-Debian.yml
+  when:
+    - ansible_os_family == 'Debian'
+    - postgresql_custom_version is defined
+
+- name: Define postgresql_repo_reference.
+  set_fact:
+    postgresql_repo_reference: "{{ __postgresql_repo_reference }}"
+  when:
+    - ansible_os_family == 'Debian'
+    - postgresql_enablerepo == 'YES'
+    - postgresql_repo_reference is not defined
+
+- name: Define postgresql_repo_key.
+  set_fact:
+    postgresql_repo_key: "{{ __postgresql_repo_key }}"
+  when:
+    - ansible_os_family == 'Debian'
+    - postgresql_enablerepo == 'YES'
+    - postgresql_repo_key is not defined
+
 - name: Define postgresql_packages.
   set_fact:
     postgresql_packages: "{{ __postgresql_packages | list }}"

--- a/vars/custom-version-Debian.yml
+++ b/vars/custom-version-Debian.yml
@@ -1,0 +1,12 @@
+---
+__postgresql_repo_key: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+__postgresql_repo_reference: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+__postgresql_version: "{{ postgresql_custom_version }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - "postgresql-{{ __postgresql_version }}"
+  - "postgresql-contrib-{{ __postgresql_version }}"
+  - "libpq-dev"


### PR DESCRIPTION
This allows the install of non-default PostgreSQL versions for Debian-based systems, optionally enabling the official PostgreSQL APT repository.

I specifically tested it with PostgreSQL 10 against the system types included in the Travis CI markup.

Let me know what you think!