### PR TITLE
Specify supported debian releases

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,10 +14,15 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - all
+        - trusty
+        - xenial
+        - bionic
+        - cosmic
     - name: Debian
       versions:
-        - all
+        - wheezy
+        - jessie
+        - stretch
   galaxy_tags:
     - database
     - postgresql


### PR DESCRIPTION
I have not tested them, just inferred from the `vars/Debian-*.yml` files which versions should work, and which don't.
Also i am not sure if this translates correctly for galaxy. I could not find any documentation about that.