### PR TITLE
Fix {{ postgresql_data_dir }} on EL7 for systemd file

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,6 @@
     name: "{{ postgresql_daemon }}"
     state: "{{ postgresql_restarted_state }}"
     sleep: 5
+- name: reload daemon
+  systemd:
+    daemon_reload: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,4 @@
     sleep: 5
 - name: reload daemon
   systemd:
-    daemon_reload: yes
+    daemon_reload: true

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -10,3 +10,10 @@
     name: "{{ postgresql_python_library }}"
     state: present
     enablerepo: "{{ postgresql_enablerepo | default(omit, true) }}"
+
+- name: Ensure PostgreSQL systemd have the rigth datadir
+  lineinfile:
+    path: "/usr/lib/systemd/system/postgresql.service"
+    regexp: "^Environment=PGDATA"
+    line: "Environment=PGDATA={{ postgresql_data_dir }}"
+  notify: reload daemon


### PR DESCRIPTION
When _{{ postgresql_data_dir }}_ are not the default vars on Centos 7, it's impossible to start the "postgresql" services because "Environment=PGDATA=..." into /usr/lib/systemd/system/postgresql.service use the default values.

This proposal fix this case.