### PR TITLE
Change order of creating users and database

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,5 +19,5 @@
     enabled: "{{ postgresql_service_enabled }}"
 
 # Configure PostgreSQL.
-- import_tasks: databases.yml
 - import_tasks: users.yml
+- import_tasks: databases.yml


### PR DESCRIPTION
When using the role to create a database that is owned by a new user I run into problems with the user not existing. 
I switched the order in which the task are done. This means that the users are created first, and then the databases are created.