### PR TITLE
Fix test for empty list

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
     group: "{{ postgresql_group }}"
     mode: 0600
   notify: restart postgresql
-  when: postgresql_hba_entries | bool
+  when: postgresql_hba_entries | length > 0
 
 - name: Ensure PostgreSQL unix socket dirs exist.
   file:


### PR DESCRIPTION
I turns out that the bool filter casts a non-empty list to false. The
proper test seems to compare its length with zero.