### PR TITLE
AWSLinux params as RedHat-2.yml, create users prior databases

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
     group: "{{ postgresql_group }}"
     mode: 0600
   notify: restart postgresql
-  when: postgresql_hba_entries | bool
+  when: postgresql_hba_entries is defined
 
 - name: Ensure PostgreSQL unix socket dirs exist.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,5 +19,5 @@
     enabled: "{{ postgresql_service_enabled }}"
 
 # Configure PostgreSQL.
-- import_tasks: databases.yml
 - import_tasks: users.yml
+- import_tasks: databases.yml

--- a/vars/RedHat-2.yml
+++ b/vars/RedHat-2.yml
@@ -1,0 +1,12 @@
+# AWS Linux
+---
+__postgresql_version: "9.2"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs


### PR DESCRIPTION
Installing on AWS Linux2 the ansible recognizes the linux type as "Redhat-2", we created a copy of the RedHat-7 config

When creating databases with owner assigned, it is necessary the user/role already exists