### PR TITLE
Add Postgres SCL support on RedHat (v2 rebase)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     - MOLECULE_DISTRO: ubuntu1604
     - MOLECULE_DISTRO: debian10
     - MOLECULE_DISTRO: debian9
+    - MOLECULE_DISTRO=centos7 RH_POSTGRESQL_SCL_VERSION=96
+    - MOLECULE_DISTRO=centos7 RH_POSTGRESQL_SCL_VERSION=10
 
 install:
   # Install test dependencies.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,12 @@
 # RHEL/CentOS only. Set a repository to use for PostgreSQL installation.
 postgresql_enablerepo: ""
 
+# RHEL/CentOS only. Use postgres from an Software Collection (SCL).
+postgresql_use_scl: false
+
+# RHEL/CentOS only. The SCL version to use.
+postgresql_scl_version: 96
+
 # Set postgresql state when configuration changes are made. Recommended values:
 # `restarted` or `reloaded`
 postgresql_restarted_state: "restarted"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -8,6 +8,8 @@
       - name: example
     postgresql_users:
       - name: jdoe
+    postgresql_scl_version: "{{ lookup('env', 'RH_POSTGRESQL_SCL_VERSION') }}"
+    postgresql_use_scl: "{{ postgresql_scl_version | default('') | length > 0 }}"
 
   pre_tasks:
     # The Fedora 30+ container images have only C.UTF-8 installed
@@ -34,6 +36,12 @@
       when:
         - ansible_os_family == 'RedHat'
         - ansible_distribution_version.split('.')[0] == '6'
+
+    - name: Install Centos SCL package
+      package:
+        name: 'centos-release-scl'
+        state: present
+      when: ansible_distribution == 'CentOS' and postgresql_use_scl
 
   roles:
     - role: geerlingguy.postgresql

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -2,5 +2,5 @@
 extends: default
 rules:
   line-length:
-    max: 120
+    max: 160
     level: warning

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -9,6 +9,14 @@
   when:
   - ansible_os_family == 'RedHat'
   - ansible_distribution != 'Fedora'
+  - not postgresql_use_scl
+
+- name: Include OS-specific variables (RedHat SCL).
+  include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}-SCL-{{ postgresql_scl_version }}.yml"
+  when:
+  - ansible_os_family == 'RedHat'
+  - ansible_distribution != 'Fedora'
+  - postgresql_use_scl
 
 - name: Include OS-specific variables (Fedora).
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"

--- a/vars/RedHat-7-SCL-10.yml
+++ b/vars/RedHat-7-SCL-10.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "10.5"
+__postgresql_data_dir: "/var/opt/rh/rh-postgresql10/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/opt/rh/rh-postgresql10/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - rh-postgresql10-postgresql-syspaths
+  - rh-postgresql10-postgresql-server-syspaths
+  - rh-postgresql10-postgresql-contrib-syspaths
+  - rh-postgresql10-postgresql-libs

--- a/vars/RedHat-7-SCL-96.yml
+++ b/vars/RedHat-7-SCL-96.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "9.6"
+__postgresql_data_dir: "/var/opt/rh/rh-postgresql96/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/opt/rh/rh-postgresql96/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - rh-postgresql96-postgresql-syspaths
+  - rh-postgresql96-postgresql-server-syspaths
+  - rh-postgresql96-postgresql-contrib-syspaths
+  - rh-postgresql96-postgresql-libs


### PR DESCRIPTION
PR based on the (nice) work by @ehelms in https://github.com/geerlingguy/ansible-role-postgresql/pull/54

Additions in this PR, apart the resolved conflicts:
* small lint fixes  (that made it into the 1.commit, for which I had to resolve conflicts anyway)
* molecule tests support for Redhat Postgres SCL .. including travis builds

Pre-requisites:
* Before deploying, the RH SCLs must be enabled, see: 
https://www.softwarecollections.org/en/scls/rhscl/rh-postgresql96/

