### PR TITLE
add postgresql_unix_socket_directories_mode option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ postgresql_group: postgres
 postgresql_unix_socket_directories:
   - /var/run/postgresql
 
+postgresql_unix_socket_directories_mode: '02755'
+
 postgresql_service_state: started
 postgresql_service_enabled: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ postgresql_group: postgres
 postgresql_unix_socket_directories:
   - /var/run/postgresql
 
-postgresql_unix_socket_directories_mode: '02755'
+# postgresql_unix_socket_directories_mode: '02775'
 
 postgresql_service_state: started
 postgresql_service_enabled: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,5 +24,5 @@
     state: directory
     owner: "{{ postgresql_user }}"
     group: "{{ postgresql_group }}"
-    mode: 02775
+    mode: "{{ postgresql_unix_socket_directories_mode }}"
   with_items: "{{ postgresql_unix_socket_directories }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,5 +24,7 @@
     state: directory
     owner: "{{ postgresql_user }}"
     group: "{{ postgresql_group }}"
-    mode: "{{ postgresql_unix_socket_directories_mode }}"
+    mode: "{{ postgresql_unix_socket_directories_mode
+        |default(__postgresql_unix_socket_directories_mode
+        |default('02775')) }}"
   with_items: "{{ postgresql_unix_socket_directories }}"

--- a/vars/Fedora-31.yml
+++ b/vars/Fedora-31.yml
@@ -9,5 +9,6 @@ __postgresql_packages:
   - postgresql-server
   - postgresql-contrib
   - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
 # Fedora 31 containers only have python3 by default
 postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
RedHat Systems have per default different permissions on the unix socket directories. Having the mode hardcoded in this role may cause idempotence issues.
The option `postgresql_unix_socket_directories_mode` allows to override the mode. An other way to solve this would be to specify the mode for each distribution in the corresponding vars file.