### PR TITLE
EL 7: Set socket dir mode to 0755

### DIFF
--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -9,3 +9,4 @@ __postgresql_packages:
   - postgresql-server
   - postgresql-contrib
   - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'


### PR DESCRIPTION
EL 7 uses 0755 as default socket dir mode. This PR will fix an idempotence issue, caused by a Postgresql restart which sets the mode back to 0755 (former 02755).