### PR TITLE
fix overwritting config options with common prefix

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Configure global settings.
   lineinfile:
     dest: "{{ postgresql_config_path }}/postgresql.conf"
-    regexp: "^#?{{ item.option }}.+$"
+    regexp: "^#?{{ item.option }}\\s*=.+$"
     line: "{{ item.option }} = '{{ item.value }}'"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ postgresql_global_config_options }}"


### PR DESCRIPTION
updated regexp for lineinfile postgresql.conf to match the whole option name before `=` sign