### PR TITLE
Change mode and owner recursive for existing data

### DIFF
--- a/tasks/initialize.yml
+++ b/tasks/initialize.yml
@@ -12,7 +12,8 @@
     owner: "{{ postgresql_user }}"
     group: "{{ postgresql_group }}"
     state: directory
-    mode: 0700
+    mode: u=rwX,g=,o=
+    recurse: yes
 
 - name: Check if PostgreSQL database is initialized.
   stat:


### PR DESCRIPTION
Add recursive mode and owner change to `postgresql_data_dir` to allow the adoption of an existing database.