### PR TITLE
Update cache for mint servers

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,7 @@
   apt:
     name: "{{ postgresql_python_library }}"
     state: present
+    update_cache: yes
 
 - name: Ensure PostgreSQL packages are installed.
   apt:


### PR DESCRIPTION
On mint servers Ansible will otherwise fail ->  "fatal: [www.example.com]: FAILED! => {"changed": false, "msg": "No package matching 'python3-psycopg2' is available"}"