### PR TITLE
Create Fedora-33.yml

### DIFF
--- a/vars/Fedora-33.yml
+++ b/vars/Fedora-33.yml
@@ -1,0 +1,14 @@
+---
+__postgresql_version: "12.4"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
+# Fedora 33 containers only have python3 by default
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
Add Fedora 33 config, quite similar to Fedora 32 config.

Without this file, on new Fedora 33 machines, the role will not work. This is basically a copy of the Fedora 32 variable file, with a minor change in the version of PostgreSQL (12.4 instead of 12.2).