### PR TITLE
Add support for manually specifying postgresql version

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure security packages are installed.
+  apt:
+    name:
+      - gnupg
+    state: present
+
 - name: Install postgres gpg key
   apt_key:
     url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,7 +11,8 @@
 
 - name: Enable postgres repo
   apt_repository:
-    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_lsb.codename }}-pgdg main"
+    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+    state: present
     update_cache: yes
 
 - name: Ensure PostgreSQL Python libraries are installed.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,10 +1,12 @@
 ---
 - name: Install postgres gpg key
-  apt_key: url="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+  apt_key:
+    url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 
 - name: Enable postgres repo
-  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_lsb.codename }}-pgdg main"
-  update_cache: yes
+  apt_repository:
+    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_lsb.codename }}-pgdg main"
+    update_cache: yes
 
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,11 @@
 ---
+- name: Install postgres gpg key
+  apt_key: url="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+
+- name: Enable postgres repo
+  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_lsb.codename }}-pgdg main"
+  update_cache: yes
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:
     name: "{{ postgresql_python_library }}"

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,12 +1,11 @@
 ---
 __postgresql_version: "11"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev
 # Debian 10 uses Python 3 by default.
 postgresql_python_library: python3-psycopg2

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,11 +1,11 @@
 ---
-__postgresql_version: "11"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
-__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_version: "{{ postgresql_version | default('11') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ __postgresql_version }}-main"
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev
 # Debian 10 uses Python 3 by default.
 postgresql_python_library: python3-psycopg2

--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -1,9 +1,9 @@
 ---
-__postgresql_version: "9.1"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
+__postgresql_version: "{{ postgresql_version | default('9.1') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev

--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -1,10 +1,9 @@
 ---
 __postgresql_version: "9.1"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,10 +1,9 @@
 ---
 __postgresql_version: "9.4"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,9 +1,9 @@
 ---
-__postgresql_version: "9.4"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
-__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_version: "{{ postgresql_version | default('9.4') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ __postgresql_version }}-main"
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,9 +1,9 @@
 ---
-__postgresql_version: "9.6"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
-__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_version: "{{ postgresql_version | default('9.6') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ __postgresql_version }}-main"
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,10 +1,9 @@
 ---
 __postgresql_version: "9.6"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,10 +1,9 @@
 ---
 __postgresql_version: "9.5"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,9 +1,9 @@
 ---
-__postgresql_version: "9.5"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
+__postgresql_version: "{{ postgresql_version | default('9.5') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,11 +1,10 @@
 ---
 __postgresql_version: "10"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev
 postgresql_python_library: python3-psycopg2

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,10 +1,10 @@
 ---
-__postgresql_version: "10"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
+__postgresql_version: "{{ postgresql_version | default('10') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev
 postgresql_python_library: python3-psycopg2

--- a/vars/Ubuntu-20.yml
+++ b/vars/Ubuntu-20.yml
@@ -1,10 +1,10 @@
 ---
-__postgresql_version: "12"
-__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
+__postgresql_version: "{{ postgresql_version | default('12') }}"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-{{ __postgresql_version }}"
   - libpq-dev
 postgresql_python_library: python3-psycopg2

--- a/vars/Ubuntu-20.yml
+++ b/vars/Ubuntu-20.yml
@@ -1,11 +1,10 @@
 ---
 __postgresql_version: "12"
-__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
-__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
-__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql
-  - postgresql-contrib
+  - "postgresql-{{ postgresql_version }}"
   - libpq-dev
 postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
As i've seen few requests about and had the same issue as other people about needing to specify manually versions, i've went ahead and added support for this. 
I've done it only for Ubuntu and Debian. 
if someone can contribute fedora and centos, please feel free to do so.