### PR TITLE
Add connection limit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If overriding, make sure you copy all of the existing entries from `defaults/mai
         login_unix_socket: # defaults to 1st of postgresql_unix_socket_directories
         port: # defaults to not set
         owner: # defaults to postgresql_user
+        conn_limit: # defaults to not set
         state: # defaults to 'present'
 
 A list of databases to ensure exist on the server. Only the `name` is required; all other properties are optional.
@@ -96,6 +97,7 @@ A list of databases to ensure exist on the server. Only the `name` is required; 
         encrypted: # defaults to not set
         priv: # defaults to not set
         role_attr_flags: # defaults to not set
+        conn_limit: # defaults to not set
         db: # defaults to not set
         login_host: # defaults to 'localhost'
         login_password: # defaults to not set

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -12,6 +12,7 @@
     login_unix_socket: "{{ item.login_unix_socket | default(postgresql_unix_socket_directories[0]) }}"
     port: "{{ item.port | default(omit) }}"
     owner: "{{ item.owner | default(postgresql_user) }}"
+    conn_limit: "{{ item.conn_limit | default(omit) }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ postgresql_databases }}"
   become: true

--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -6,6 +6,7 @@
     encrypted: "{{ item.encrypted | default(omit) }}"
     priv: "{{ item.priv | default(omit) }}"
     role_attr_flags: "{{ item.role_attr_flags | default(omit) }}"
+    conn_limit: "{{ item.conn_limit | default(omit) }}"
     db: "{{ item.db | default(omit) }}"
     login_host: "{{ item.login_host | default('localhost') }}"
     login_password: "{{ item.login_password | default(omit) }}"


### PR DESCRIPTION
Adds `conn_limit` option. This feature was also requested in https://github.com/geerlingguy/ansible-role-postgresql/issues/67