### PR TITLE
Fix  error when port is not the default one

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -3,6 +3,11 @@
   postgresql_user:
     name: "{{ item.name }}"
     password: "{{ item.password | default(omit) }}"
+    login_host: "{{ item.login_host | default('localhost') }}"
+    login_password: "{{ item.login_password | default(omit) }}"
+    login_user: "{{ item.login_user | default(postgresql_user) }}"
+    login_unix_socket: "{{ item.login_unix_socket | default(postgresql_unix_socket_directories[0]) }}"
+    port: "{{ item.port | default(omit) }}"
   with_items: "{{ postgresql_users }}"
   no_log: "{{ postgres_users_no_log }}"
   become: true


### PR DESCRIPTION
If we configure another port than the default one, the check of the users fails because ansible cannot connect to postgresql. We must provide conneciton configration to this task too