### PR TITLE
users can not be added when socket_dir change from default

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,9 +1,10 @@
 ---
 - name: Ensure PostgreSQL users are present.
   postgresql_user:
-    name: "{{ item.name }}"
-    password: "{{ item.password | default(omit) }}"
-  with_items: "{{ postgresql_users }}"
+    name: "{{ item.0.name }}"
+    password: "{{ item.0.password | default(omit) }}"
+    login_unix_socket: "{{ item.1 }}"
+  loop: "{{ postgresql_users|zip(postgresql_unix_socket_directories) | list }}"
   no_log: "{{ postgres_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"


### PR DESCRIPTION
When changing default socker_dir path the user cannot be added. This fix will get the socke directories and add users there