### PR TITLE
ADD: dependency on postrgresql collection required for users.yml task

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
-dependencies: []
+dependencies:
+  - community.postgresql
 
 galaxy_info:
   role_name: postgresql


### PR DESCRIPTION
Should address the below issue, as always thanks for your epic contributions to the ansible ecosystem.

```
ansible-playbook -i inventory/01-network.yml play.configure-gateway.yml
ERROR! couldn't resolve module/action 'postgresql_user'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/ansible/galaxy-roles/geerlingguy.ansible-role-postgresql/tasks/users.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Ensure PostgreSQL users are present.
  ^ here
```