### PR TITLE
Fix: Remove SSH Pipelining as described in issue #139.

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -16,6 +16,3 @@
   with_items: "{{ postgresql_databases }}"
   become: true
   become_user: "{{ postgresql_user }}"
-  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
-  vars:
-    ansible_ssh_pipelining: true

--- a/tasks/initialize.yml
+++ b/tasks/initialize.yml
@@ -24,6 +24,3 @@
   when: not pgdata_dir_version.stat.exists
   become: true
   become_user: "{{ postgresql_user }}"
-  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
-  vars:
-    ansible_ssh_pipelining: true

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,8 +7,5 @@
   no_log: "{{ postgres_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
-  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
-  vars:
-    ansible_ssh_pipelining: true
   environment:
     PGOPTIONS: "{{ (postgresql_auth_method == 'scram-sha-256') | ternary('-c password_encryption=scram-sha-256', '') }}"

--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -17,8 +17,5 @@
   no_log: "{{ postgres_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
-  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
-  vars:
-    ansible_ssh_pipelining: true
   environment:
     PGOPTIONS: "{{ (postgresql_auth_method == 'scram-sha-256') | ternary('-c password_encryption=scram-sha-256', '') }}"


### PR DESCRIPTION
Remove SSH Pipelining as described in issue #139.

* Makes it possible to run molecule tests with podman but keeps compatibility with docker

Tested with `podman version 3.1.2` on Fedora 33 and `Docker version 18.09.1, build 4c52b90` on Debian 10.