### PR TITLE
Restrict postgresql.conf priviliges

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,7 +5,7 @@
     regexp: "^#?{{ item.option }}.+$"
     line: "{{ item.option }} = '{{ item.value }}'"
     state: "{{ item.state | default('present') }}"
-    mode: 0644
+    mode: 0640
   with_items: "{{ postgresql_global_config_options }}"
   notify: restart postgresql
 


### PR DESCRIPTION
There is no reason why the postgresql.conf should be readable by others. 