### PR TITLE
Support Debian Bullseye aka Debian 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - ubuntu2004
           - ubuntu1804
           - debian10
+          - debian11
 
     steps:
       - name: Check out the codebase.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,7 @@ galaxy_info:
         - jessie
         - stretch
         - buster
+        - bullseye
   galaxy_tags:
     - database
     - postgresql

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "13"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
Title says it all. This commit adds support for the next Debian version.