### PR TITLE
Add support for Amazon-2 (same as RedHat-7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           - ubuntu1804
           - debian10
           - debian11
+          - amazonlinux2
 
     steps:
       - name: Check out the codebase.

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -9,6 +9,11 @@
   when:
   - ansible_os_family == 'RedHat'
   - ansible_distribution != 'Fedora'
+  - ansible_distribution != 'Amazon'
+
+- name: Include OS-specific variables (Amazon).
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_distribution == 'Amazon'
 
 - name: Include OS-specific variables (Fedora).
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"

--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "9.2"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs


### PR DESCRIPTION
This just tweaks vars a little to ensure Amazon Linux 2 is treated the same as RedHat-7.

Tested installation, creating a db, and adding a user successfully with docker image: `robertdebock/amazonlinux` (update: also tested with `geerlingguy/docker-amazonlinux2-ansible` and updated `ci.yml` accordingly)