### PR TITLE
Add recognition of Alma/Rocky Linux as RHEL 8 analogs for Ansible < 2.11

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,11 @@
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
+- include_tasks: setup-RedHat.yml
+  when:
+    - ansible_version.string is version('2.11', '<')
+    - ansible_os_family in ['Rocky', 'AlmaLinux']
+
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -11,6 +11,12 @@
   - ansible_distribution != 'Fedora'
   - ansible_distribution != 'Amazon'
 
+- name: Include OS-specific variables (Rocky Linux, AlmaLinux).
+  include_vars: "RedHat-{{ ansible_distribution_major_version }}.yml"
+  when:
+  - ansible_version.string is version('2.11', '<')
+  - ansible_os_family in ['AlmaLinux', 'Rocky']
+
 - name: Include OS-specific variables (Amazon).
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
   when: ansible_distribution == 'Amazon'


### PR DESCRIPTION
AlmaLinux and Rocky Linux seem to become successors of CentOS 8 as RHEL binary rebuild, but Ansible `< 2.11` does not recognize them as RedHat-family (`ansible_os_family` variable is not set to `RedHat`).

It seems that there are no other reasons to increase current minimal Ansible version from `2.8`.