### PR TITLE
Fix collection dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -36,3 +36,5 @@ galaxy_info:
     - postgresql
     - postgres
     - rdbms
+collections:
+  - community.general


### PR DESCRIPTION
```
fatal: [debian-11]: FAILED! => {
      "reason": "couldn't resolve module/action 'locale_gen'. This often indicates a misspelling, missing collection, or incorrect module path.\n\nThe error appears to be in '/home/runner/.cache/molecule/pulp_installer/source-static/roles/geerlingguy.postgresql/tasks/setup-Debian.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure all configured locales are present.\n  ^ here\n"
  }
  ```