### PR TITLE
Adding support for Fedora 34 and Fedora 35

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,8 @@ galaxy_info:
         - 31
         - 32
         - 33
+        - 34
+        - 35
     - name: Ubuntu
       versions:
         - xenial


### PR DESCRIPTION
If you have a collection that refers to this role, when you try to install the collection on Fedora 34 and 35, the collection will not install because F34/35 it's supported in the platforms