### PR TITLE
Support Ubuntu 22

### DIFF
--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "14"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
Ubuntu 22 was recently released, lets support it.

i was not sure though, which __postgresql_daemon format is prefered. Both are available under Ubuntu 22:
```
 __postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
```
vs
```
 __postgresql_daemon: postgresql
```

Best,
Simon