### PR TITLE
Adding support for EL9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
     - name: Fedora
       versions:
         - 30

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,0 +1,12 @@
+---
+__postgresql_version: "13"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+__postgresql_unix_socket_directories_mode: '0755'
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
I could not find one Container image for EL9 under `${MOLECULE_DISTRO} on DockerHub`, rebuild or stream, do you plan to add support for EL9 in the future @geerlingguy ?

