### PR TITLE
Adding support for Fedora 36

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
         - 33
         - 34
         - 35
+        - 36
     - name: Ubuntu
       versions:
         - xenial

--- a/vars/Fedora-36.yml
+++ b/vars/Fedora-36.yml
@@ -1,0 +1,14 @@
+---
+__postgresql_version: "13.4"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
+# Fedora 32 containers only have python3 by default
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
Ansible is not able to install this role on Fedora 36. After looking through the recent commits regarding adding Fedora 34 and 35 I believe this PR should fix it.