### PR TITLE
Added support for Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - rockylinux8
           - centos7
           - fedora36
+          - ubuntu2204
           - ubuntu2004
           - ubuntu1804
           - debian10

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,6 +27,7 @@ galaxy_info:
         - xenial
         - bionic
         - focal
+        - jammy
     - name: Debian
       versions:
         - wheezy

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "14"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
The older file worked just fine with version update. Frankly copied Fedora 36 commit for the molecule distro and meta file changes.