### PR TITLE
Fix Readme comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ If overriding, make sure you copy all of the existing entries from `defaults/mai
         template: # defaults to 'template0'
         login_host: # defaults to 'localhost'
         login_password: # defaults to not set
-        login_user: # defaults to 'postgresql_user'
+        login_user: # defaults to '{{ postgresql_user }}'
         login_unix_socket: # defaults to 1st of postgresql_unix_socket_directories
         port: # defaults to not set
-        owner: # defaults to postgresql_user
+        owner: # defaults to '{{ postgresql_user }}'
         state: # defaults to 'present'
 
 A list of databases to ensure exist on the server. Only the `name` is required; all other properties are optional.


### PR DESCRIPTION
Fix description of two defaults, as previously it implied a hardcoded value was default.