### PR TITLE
Add `no_log` option to `postgresql_db` task to prevent output of `login_password`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,9 @@ postgresql_databases: []
 #   owner: # defaults to postgresql_user
 #   state: # defaults to 'present'
 
+# Whether to output db data when managing databases.
+postgres_dbs_no_log: true
+
 # Users to ensure exist.
 postgresql_users: []
 # - name: jdoe #required; the rest are optional

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -14,6 +14,7 @@
     owner: "{{ item.owner | default(postgresql_user) }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ postgresql_databases }}"
+  no_log: "{{ postgres_dbs_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509


### PR DESCRIPTION
Without this, the `login_password` may be dumped to Ansible's output: ![image](https://user-images.githubusercontent.com/29434548/208458090-cbafe312-bb3f-4581-950d-0b2f19ad5e60.png).

This PR adds the option to disable the log for `postgresql_db`, copied exactly from the existing feature for `postgresql_user`