### PR TITLE
feat: add global default variable for lc_collate

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ If overriding, make sure you copy all of the existing entries from `defaults/mai
       - 'en_US.UTF-8'
 
 (Debian/Ubuntu only) Used to generate the locales used by PostgreSQL databases.
-
+    postgresql_default_locale: 'en_US.UTF-8' # Default `lc_collate` and `lc_ctype` value
     postgresql_databases:
       - name: exampledb # required; the rest are optional
-        lc_collate: # defaults to 'en_US.UTF-8'
-        lc_ctype: # defaults to 'en_US.UTF-8'
+        lc_collate: # defaults to {{ postgresql_default_locale }}
+        lc_ctype: # defaults to {{ postgresql_default_locale }}
         encoding: # defaults to 'UTF-8'
         template: # defaults to 'template0'
         login_host: # defaults to 'localhost'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,11 +38,12 @@ postgresql_hba_entries:
 postgresql_locales:
   - 'en_US.UTF-8'
 
+postgresql_default_locale: 'en_US.UTF-8'
 # Databases to ensure exist.
 postgresql_databases: []
 # - name: exampledb # required; the rest are optional
-#   lc_collate: # defaults to 'en_US.UTF-8'
-#   lc_ctype: # defaults to 'en_US.UTF-8'
+#   lc_collate: # defaults to 'postgresql_default_locale'
+#   lc_ctype: # defaults to 'postgresql_default_locale'
 #   encoding: # defaults to 'UTF-8'
 #   template: # defaults to 'template0'
 #   login_host: # defaults to 'localhost'

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,8 +2,8 @@
 - name: Ensure PostgreSQL databases are present.
   postgresql_db:
     name: "{{ item.name }}"
-    lc_collate: "{{ item.lc_collate | default('en_US.UTF-8') }}"
-    lc_ctype: "{{ item.lc_ctype | default('en_US.UTF-8') }}"
+    lc_collate: "{{ item.lc_collate | default({{ postgresql_default_locale }}) }}"
+    lc_ctype: "{{ item.lc_ctype | default({{ postgresql_default_locale }}) }}"
     encoding: "{{ item.encoding | default('UTF-8') }}"
     template: "{{ item.template | default('template0') }}"
     login_host: "{{ item.login_host | default('localhost') }}"


### PR DESCRIPTION
Hello,

This Pull Request introduces a refinement to the PostgreSQL database task, providing an option for setting a global default locale. While the existing role does permit locale modification at the individual database level, I observed that there are use cases where one might need to change the default locale across all databases without having to specify `lc_collate` and `lc_ctype` for each one. This led me to propose this enhancement.

The following lines in `databases.yml` have been updated to use the new `postgresql_default_locale` variable when individual `lc_collate` and `lc_ctype` values are not provided:

```
lc_collate: "{{ item.lc_collate | default({{ postgresql_default_locale }}) }}"
lc_ctype: "{{ item.lc_ctype | default({{ postgresql_default_locale }}) }}"
```

I have added the `postgresql_default_locale` variable to the `defaults/main.yml` file. This new variable allows users to define a global default locale:

```
postgresql_default_locale: 'en_US.UTF-8'
```

Additionally, I have updated the README to explain the purpose of this new variable and how to use it. The documentation clarifies that `postgresql_default_locale` is used to set default `lc_collate` and `lc_ctype` values for all databases, unless specifically overridden for a particular database.

This modification aims to increase the role's versatility and simplify PostgreSQL database configuration by offering a global default locale setting. 

I look forward to hearing your thoughts on this proposed change.

Thank you.
