### PR TITLE
Add PostgreSQL apt repo and signing key for installing specific versions of Postgres for debian based distros

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,14 +1,17 @@
 ---
 - name: Add PostgreSQL APT repo
   command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  become: true
 
 - name: Import and Write gpg key to pgdg.asc
   get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
+  become: true
 
 - name: Update cache
   apt: update_cache=yes state=latest
+  become: true
 
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,17 +2,13 @@
 - name: Add PostgreSQL APT repo
   command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
-- name: Import the repository signing key
-  command: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc
-  register: downloaded_key
-
-- name: Write gpg key to pgdg.asc
-  copy:
-    content: "{{ downloaded_key.stdout }}"
+- name: Import and Write gpg key to pgdg.asc
+  get_url: 
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
 
 - name: Update cache
-  apt:  update_cache=yes state=latest
+  apt: update_cache=yes state=latest
 
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,7 +3,7 @@
   command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 - name: Import and Write gpg key to pgdg.asc
-  get_url: 
+  get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,20 +1,20 @@
 ---
-- name: Check if key is present
+- name: Check if signing key is present
   stat:
     path: /etc/apt/trusted.gpg.d/pgdg.asc
-  register: st_pgdg
-
-- name: Add PostgreSQL APT repo
-  command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-  become: true
-  when: not st_pgdg.stat.exists
+  register: postgresql_st_pgdg
 
 - name: Import and Write gpg key to pgdg.asc
   get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
   become: true
-  when: not st_pgdg.stat.exists
+  when: not postresql_st_pgdg.stat.exists
+
+- name: Add postgresql repository into sources list
+  ansible.builtin.apt_repository:
+    repo: "deb http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+    state: present
 
 - name: Update cache
   apt: update_cache=yes state=latest

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,6 +11,9 @@
     content: "{{ downloaded_key.stdout }}"
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
 
+- name: Update cache
+  apt:  update_cache=yes state=latest
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:
     name: "{{ postgresql_python_library }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,7 +9,7 @@
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
   become: true
-  when: not postresql_st_pgdg.stat.exists
+  when: not postgresql_st_pgdg.stat.exists
 
 - name: Add postgresql repository into sources list
   ansible.builtin.apt_repository:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,16 @@
 ---
+- name: Add PostgreSQL APT repo
+  command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+- name: Import the repository signing key
+  command: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc
+  register: downloaded_key
+
+- name: Write gpg key to pgdg.asc
+  copy:
+    content: "{{ downloaded_key.stdout }}"
+    dest: /etc/apt/trusted.gpg.d/pgdg.asc
+
 - name: Ensure PostgreSQL Python libraries are installed.
   apt:
     name: "{{ postgresql_python_library }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,13 +1,20 @@
 ---
+- name: Check if key is present
+  stat:
+    path: /etc/apt/trusted.gpg.d/pgdg.asc
+  register: st_pgdg
+
 - name: Add PostgreSQL APT repo
   command: sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   become: true
+  when: not st_pgdg.stat.exists
 
 - name: Import and Write gpg key to pgdg.asc
   get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdg.asc
   become: true
+  when: not st_pgdg.stat.exists
 
 - name: Update cache
   apt: update_cache=yes state=latest


### PR DESCRIPTION
# Changes

Included tasks for adding PostgreSQL apt repo and signing key

# Reason for changes

Certain applications have need for specific versions of ```postgresql```. The default packages variables ```postgres_packages``` even when initialized to something like ```postgresql-15 and postgresql-client-15``` are not recognized by apt without adding the repo. Hence, it would be helpful for debian based systems to include the repo such that we can install these packages.

Installing the default packages ```postgresql``` and ```postgresql-contrib``` installs the latest version of postgres for the particular distribution.

I have tested the above code on an Ubuntu 22.04 Live Server VM. Currently without the above changes, installing the packages via apt only installs the latest version which as of writing this PR is ```postgres-16```. With the changes I am able to install the particular version of postgres on the server.

Please let me know if there are any further changes that I might need to make.

fixes #242 