### PR TITLE
set the default postgres version to "13" for RHEL9 (fixes #252)

### DIFF
--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,5 +1,5 @@
 ---
-__postgresql_version: "10"
+__postgresql_version: "13"
 __postgresql_data_dir: "/var/lib/pgsql/data"
 __postgresql_bin_path: "/usr/bin"
 __postgresql_config_path: "/var/lib/pgsql/data"


### PR DESCRIPTION
As per [official RHEL documentation ](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_using_database_servers/using-postgresql_configuring-and-using-database-servers#:~:text=RHEL%209%20provides%20PostgreSQL%2013,the%20postgresql%3A15%20module%20stream) the default version of postgres should be v13 not v10 as it is currently set.


>RHEL 9 provides PostgreSQL 13 as the initial version of this Application Stream, which you can install easily as an RPM package.
>
>Additional PostgreSQL versions are provided as modules with a shorter life cycle in minor releases of RHEL 9:
>
>RHEL 9.2 introduced PostgreSQL 15 as the postgresql:15 module stream
>RHEL 9.4 introduced PostgreSQL 16 as the postgresql:16 module stream
