### PR TITLE
Feat: add vars for Fedora 39, 40 and 41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       matrix:
         distro:
           - rockylinux9
-          - fedora38
+          - fedora39
+          - fedora40
           - ubuntu2204
           - ubuntu2004
           - debian11

--- a/vars/Fedora-39.yml
+++ b/vars/Fedora-39.yml
@@ -1,0 +1,14 @@
+---
+__postgresql_version: "15.6"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
+# Fedora 32 containers only have python3 by default
+postgresql_python_library: python3-psycopg2

--- a/vars/Fedora-40.yml
+++ b/vars/Fedora-40.yml
@@ -1,0 +1,14 @@
+---
+__postgresql_version: "16.3"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
+# Fedora 32 containers only have python3 by default
+postgresql_python_library: python3-psycopg2

--- a/vars/Fedora-41.yml
+++ b/vars/Fedora-41.yml
@@ -1,0 +1,14 @@
+---
+__postgresql_version: "16.3"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-server
+  - postgresql-contrib
+  - postgresql-libs
+__postgresql_unix_socket_directories_mode: '0755'
+# Fedora 32 containers only have python3 by default
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
This PR adds the vars files for Fedora versions 39, 40 and the upcoming 41. 41 is currently in Beta and past the final freeze, so the Postgesql version is not expected to change anymore.