### PR TITLE
fix users password spitted in the logs

### DIFF
--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -24,7 +24,7 @@
 
 - name: Ensure PostgreSQL users do not use deprecated privileges settings
   debug:
-    msg "Postgresql user {{ item.name }} uses deprecated privileges settings. See https://github.com/geerlingguy/ansible-role-postgresql/issues/254"
+    msg: "Postgresql user {{ item.name }} uses deprecated privileges settings. See https://github.com/geerlingguy/ansible-role-postgresql/issues/254"
   with_items: "{{ postgresql_users }}"
   no_log: "{{ postgres_users_no_log }}"
   when: item.priv is defined

--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -26,6 +26,7 @@
   debug:
     msg "Postgresql user {{ item.name }} uses deprecated privileges settings. See https://github.com/geerlingguy/ansible-role-postgresql/issues/254"
   with_items: "{{ postgresql_users }}"
+  no_log: "{{ postgres_users_no_log }}"
   when: item.priv is defined
 
 - name: Ensure PostgreSQL users privileges are configured correctly.


### PR DESCRIPTION
The recently added task to warn about priv deprecation is spitting the user password in the ansible logs, caused by lack of `no_log` attribute as in similar tasks using `with_items: "{{ postgresql_users }}"`