### PR TITLE
Assume default 'log' for postgres_log_dir

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -59,7 +59,7 @@
   set_fact:
     # postgresql_global_config_options is an array but its keys are unique, so it can be converted to dict,
     # to easily get the value under the 'log_directory' key
-    postgresql_log_dir: "{{ (postgresql_global_config_options | items2dict(key_name='option', value_name='value')).log_directory }}"
+    postgresql_log_dir: "{{ (postgresql_global_config_options | items2dict(key_name='option', value_name='value')).log_directory | default('log') }}"
 
 - name: Define postgresql_effective_log_dir, if postgresql_log_dir is absolute
   set_fact:


### PR DESCRIPTION
Fixes the following error:

  TASK [geerlingguy.postgresql : Define postgresql_log_dir.]
  fatal: [localhost]: FAILED! => {"msg": "The task includes an
  option with an undefined variable. The error was: 'dict object'
  has no attribute 'log_directory'. 'dict object' has no attribute

when reporting and logging will be redirected to journald by using the following configuration:

postgresql_global_config_options:
  - option: log_destination value: 'stderr'
  - option: logging_collector value: 'off'
  - option: log_line_prefix value: ''

Note: the log_directory is not used when 'logging_collector'
      is 'off'.