### PR TITLE
Sensitive password field exposed when the task of checking deprecated privileges settings is skipped due to with_items loop

### DIFF
--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -25,7 +25,7 @@
 - name: Ensure PostgreSQL users do not use deprecated privileges settings
   debug:
     msg "Postgresql user {{ item.name }} uses deprecated privileges settings. See https://github.com/geerlingguy/ansible-role-postgresql/issues/254"
-  with_items: "{{ postgresql_users }}"
+  with_items: "{{ postgresql_users | map('combine', {'password': '***hidden***'}) | list }}"
   when: item.priv is defined
 
 - name: Ensure PostgreSQL users privileges are configured correctly.


### PR DESCRIPTION
When the role runs the task:

```yaml
- name: Ensure PostgreSQL users do not use deprecated privileges settings
  debug:
    msg "Postgresql user {{ item.name }} uses deprecated privileges settings. See https://github.com/geerlingguy/ansible-role-postgresql/issues/254"
  with_items: "{{ postgresql_users }}"
  when: item.priv is defined
```

Ansible prints the full contents of item in the skipped message, which includes sensitive fields such as the PostgreSQL user's password.
Example output:

```
TASK [geerlingguy.postgresql : Ensure PostgreSQL users do not use deprecated privileges settings] ***********************************************************
skipping: [boo.example.com] => (item={'name': 'example_user', 'password': 'xDsfdsf8v4Zz', 'encrypted': True, 'db': 'foo_db', 'login_host': 'localhost', 'port': 5432, 'state': 'present'})
```

This results in a security risk, as sensitive values are exposed even though the task itself is skipped and does not explicitly log them.