### PR TITLE
debian-trixie support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,7 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
+        - trixie
   galaxy_tags:
     - database
     - postgresql

--- a/vars/Debian-13.yml
+++ b/vars/Debian-13.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "17"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: "postgresql@{{ postgresql_version }}-main"
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
A simple PR to ensure debian 13 compatibility of the role.