### PR TITLE
Add Amazon Linux 2023 support

### DIFF
--- a/vars/Amazon-2023.yml
+++ b/vars/Amazon-2023.yml
@@ -8,4 +8,3 @@ __postgresql_packages:
   - postgresql16
   - postgresql16-server
   - postgresql16-contrib
-

--- a/vars/Amazon-2023.yml
+++ b/vars/Amazon-2023.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "16"
+__postgresql_data_dir: "/var/lib/pgsql/data"
+__postgresql_bin_path: "/usr/bin"
+__postgresql_config_path: "/var/lib/pgsql/data"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql16
+  - postgresql16-server
+  - postgresql16-contrib
+


### PR DESCRIPTION
Amazon Linux 2023 triggers inclusion of `vars/Amazon-2023.yml` via `tasks/variables.yml`, but the file is missing causing the role to fail on AL2023.

Add `vars/Amazon-2023.yml` with PostgreSQL 16 package names and paths matching AL2023.

Tested on Amazon Linux 2023: `postgresql.service` uses `PGDATA=/var/lib/pgsql/data`; role installs PostgreSQL 16 from the Amazon Linux repos (tested with 16.11); `select version()` returns PostgreSQL 16.x.