### PR TITLE
Add Ubuntu 26.04 (Resolute) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           # See: https://github.com/geerlingguy/docker-rockylinux9-ansible/issues/6
           # - rockylinux9
           # - fedora41
+          - ubuntu2604
           - ubuntu2404
           - ubuntu2204
           - debian11

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,8 @@ galaxy_info:
         - bionic
         - focal
         - jammy
+        - noble
+        - resolute
     - name: Debian
       versions:
         - buster

--- a/vars/Ubuntu-26.yml
+++ b/vars/Ubuntu-26.yml
@@ -1,0 +1,11 @@
+---
+__postgresql_version: "18"
+__postgresql_data_dir: "/var/lib/postgresql/{{ __postgresql_version }}/main"
+__postgresql_bin_path: "/usr/lib/postgresql/{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/etc/postgresql/{{ __postgresql_version }}/main"
+__postgresql_daemon: postgresql
+__postgresql_packages:
+  - postgresql
+  - postgresql-contrib
+  - libpq-dev
+postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
> [!NOTE]
> The work on this PR was sponsored by [Devopness](https://github.com/devopness/devopness) 

## Summary

This PR adds support for Ubuntu 26.04 (Resolute) by creating the `vars/Ubuntu-26.yml` file with appropriate PostgreSQL package definitions.

## Changes

- Added `vars/Ubuntu-26.yml` with PostgreSQL 18 as the default database package
- Updated `meta/main.yml` to include `noble` and `resolute` in supported Ubuntu versions
- Added `ubuntu2604` to the CI test matrix in `.github/workflows/ci.yml`

## Ubuntu 26.04 PostgreSQL Packages

Ubuntu 26.04 introduces PostgreSQL 18 [#1](https://packages.ubuntu.com/resolute/postgresql-18) [#2](https://packages.ubuntu.com/resolute/postgresql) as the default database, moving from PostgreSQL 16 [#1](https://packages.ubuntu.com/noble/postgresql-16) [#2](https://packages.ubuntu.com/noble/postgresql) in Ubuntu 24.04.

Additional PostgreSQL versions (8.2 through 19) are available via the [PGDG repository](https://ftp.postgresql.org/pub/repos/apt/dists/resolute-pgdg/).

You can verify the default version directly:
```bash
docker run --rm ubuntu:26.04 bash -c "apt-get update -qq && apt-cache policy postgresql"
```

## Testing

Tested with Molecule using `molecule/default/molecule.yml`:

```bash
MOLECULE_DISTRO="ubuntu2604" molecule test --scenario-name default
```