### PR TITLE
fix: declare the community.postgresql requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ No special requirements; note that this role requires root access, so either run
     - role: geerlingguy.postgresql
       become: yes
 ```
+
+If you are running this role with `ansible-core`, install the
+`community.postgresql` collection first so the PostgreSQL modules used by the
+role are available.
 ## Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure PostgreSQL databases are present.
-  postgresql_db:
+  community.postgresql.postgresql_db:
     name: "{{ item.name }}"
     lc_collate: "{{ item.lc_collate | default('en_US.UTF-8') }}"
     lc_ctype: "{{ item.lc_ctype | default('en_US.UTF-8') }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure PostgreSQL users are present.
-  postgresql_user:
+  community.postgresql.postgresql_user:
     name: "{{ item.name }}"
     password: "{{ item.password | default(omit) }}"
     login_host: "{{ item.login_host | default('localhost') }}"

--- a/tasks/users_props.yml
+++ b/tasks/users_props.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure PostgreSQL users are configured correctly.
-  postgresql_user:
+  community.postgresql.postgresql_user:
     name: "{{ item.name }}"
     password: "{{ item.password | default(omit) }}"
     encrypted: "{{ item.encrypted | default(omit) }}"
@@ -32,7 +32,7 @@
   when: item.priv is defined
 
 - name: Ensure PostgreSQL users privileges are configured correctly.
-  postgresql_privs:
+  community.postgresql.postgresql_privs:
     roles: "{{ item.roles }}"
     db: "{{ item.db }}"
     privs: "{{ item.privs | default(omit) }}"


### PR DESCRIPTION
Fixes #301

## Summary
- switch the role's PostgreSQL tasks to `community.postgresql.*` modules
- document the `community.postgresql` collection requirement for `ansible-core` users

## Testing
- `git diff --check`
- `ansible-playbook --syntax-check` could not be run because `ansible-playbook` is not installed in this environment
